### PR TITLE
Updated the install command for 4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Install
 With [fisherman]
 ```
-fisher add jomik/fish-gruvbox
+fisher install jomik/fish-gruvbox
 ```
 
 This will expose the function called `theme_gruvbox`.


### PR DESCRIPTION
The command in fisher to install a plugin is now:
```
fisher install...
```